### PR TITLE
Making restiq request mock use http.IncomingMessage for event emitter.

### DIFF
--- a/lib/functional-test-result.js
+++ b/lib/functional-test-result.js
@@ -207,7 +207,11 @@ class FunctionalTestResult {
         // If restify, use http.IncomingMessage as the event emitter because
         // restify uses that object directly and adds extra functions to
         // the prototype.
-        if (this.functionalTest.serverType === "restify") {
+        // If restiq.mw.readBody is used to read the body and readBinary option
+        // is set to false or undefined it will attempt to
+        // call `req.setEncoding("utf8")` which is a function
+        // http.IncomingMessage implements from the Readable Stream interface.
+        if (this.functionalTest.serverType === "restify" || this.functionalTest.serverType === "restiq") {
             options.eventEmitter = http.IncomingMessage;
         }
 

--- a/spec/restiq.spec.js
+++ b/spec/restiq.spec.js
@@ -15,15 +15,14 @@ function sendToRestiq(res, statusCode, headers, body) {
     res.end(body);
 }
 
-
 restiq = require("restiq");
 routes = require("./fixture/routes");
 describe("restiq", () => {
-    var functionalTest;
+    var app, functionalTest;
 
     beforeEach(() => {
         return jasmine.restiqFunctionalTestAsync((createServer) => {
-            var app, config;
+            var config;
 
             config = {
                 createServer
@@ -39,6 +38,19 @@ describe("restiq", () => {
     });
     it("gets /", () => {
         return functionalTest.requestAsync("GET", "/").then((result) => {
+            expect(result.statusCode).toBe(200);
+            expect(result.body).toBe("this works");
+        });
+    });
+    it("gets / with a body using restiq.mw.readBody", () => {
+        var params;
+
+        params = {
+            body: "Just saying hi"
+        };
+        app.addStep(restiq.mw.readBody);
+
+        return functionalTest.requestAsync("GET", "/", params).then((result) => {
             expect(result.statusCode).toBe(200);
             expect(result.body).toBe("this works");
         });


### PR DESCRIPTION
This is because the restiq.mw.readBody middleware sets the encoding on the
request if readBinary is set to false. This function only exists if our
request implements the Readable Stream interface.