### PR TITLE
Not deleting res.getHeader Restify defaults everything to application/json

### DIFF
--- a/lib/functional-test-result.js
+++ b/lib/functional-test-result.js
@@ -301,7 +301,6 @@ class FunctionalTestResult {
         // framework use the send method that was added to the prototype.
         delete res.contentType;
         delete res.format;
-        delete res.getHeader;
         delete res.send;
 
         return res;


### PR DESCRIPTION
I see no reason to delete this off of the response but I could be wrong. Works with Restify and Restiq.
Restify does this to determine type:

`var type = this.contentType || this.getHeader('Content-Type');`

If neither are set it does this

```
    if (!type) {
        if (this.req.accepts(this.acceptable)) {
            type = this.req.accepts(this.acceptable);
        }
        ....
    }
```

In the latest version of Restify they just straight up default to application/json.