### PR TITLE
Deleting mock functions added by node-mock-http mockResponse

### DIFF
--- a/lib/functional-test-result.js
+++ b/lib/functional-test-result.js
@@ -304,6 +304,14 @@ class FunctionalTestResult {
         delete res.getHeader;
         delete res.send;
 
+        // If we delete res.getHeader we have to delete header and
+        // setHeader so that Restify falls back to http's functions so they set
+        // headers on the same property to avoid inconsistency.
+        if (this.functionalTest.serverType === "restify") {
+            delete res.header;
+            delete res.setHeader;
+        }
+
         return res;
     }
 


### PR DESCRIPTION
Also added a test case for the scenario I am fixing.